### PR TITLE
Fix syntax for dpic

### DIFF
--- a/grap_pic.cc
+++ b/grap_pic.cc
@@ -384,7 +384,7 @@ void Picframe::draw(frame *) {
     draw_grid_f draw_grid(this);
 
     cout << "Frame: [" << endl;
-    cout << "Origin: " << endl;
+    cout << "Origin: [ ]" << endl;
     frame_line(0,ht,left_side);
     frame_line(wid,0,top_side);
     frame_line(0,-ht,right_side);


### PR DESCRIPTION
For some reason the dpic implementation from https://ece.uwaterloo.ca/~aplevich/dpic/ thinks label followed by label is a syntax error. With this fix the output of grap can be used with dpic to produce TiKz plots for TeX.

<img width="1157" alt="sample" src="https://github.com/snorerot13/grap/assets/22933696/38b8ccb4-609c-4c53-ab5a-7420c550fbee">
